### PR TITLE
feat/#51

### DIFF
--- a/src/main/java/group18/PUM.java
+++ b/src/main/java/group18/PUM.java
@@ -1,9 +1,10 @@
 package group18;
 
+import group18.parameters.CONNECTORS;
 import static group18.parameters.CONNECTORS.*;
 
 public class PUM {
-    public static boolean[][] getPUM(boolean[] CMV, group18.parameters.CONNECTORS[][] LCM) {
+    public static boolean[][] getPUM(boolean[] CMV, CONNECTORS[][] LCM) {
         boolean[][] pum = new boolean[15][15];
         for (int i = 0; i < CMV.length; i++) {
             for (int j = 0; j < CMV.length; j++) {

--- a/src/test/java/group18/PUMTest.java
+++ b/src/test/java/group18/PUMTest.java
@@ -3,10 +3,10 @@ package group18;
 import group18.parameters.CONNECTORS;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PUMTest {
     @Test
@@ -23,13 +23,8 @@ public class PUMTest {
                 else if (rndIdx == 1) LCM[i][j] = CONNECTORS.ANDD;
                 else LCM[i][j] = CONNECTORS.ORR;
             }
-            System.out.println(Arrays.toString(LCM[i]));
         }
-        System.out.println(Arrays.toString(CMV));
         boolean[][] pum = group18.PUM.getPUM(CMV, LCM);
-        for (boolean[] row : pum) {
-            System.out.println(Arrays.toString(row));
-        }
         for (int i = 0; i < pum.length; i++) {
             for (int j = 0; j < pum[i].length; j++) {
                 if (i == j) continue;


### PR DESCRIPTION
Add implementation and test with random assignment to CMV and LCM

Use of BMATRIX and VECTOR for CMV and LCM seems unnecessary for implementation in java, since indexing is not supported by a normal class. This implementation uses boolean[] and boolean[][] types

This pull request closes #51.